### PR TITLE
Document uinput module necessity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,12 @@ i↑ ⟶ up↑
 rightalt↑ ⟶ ∅
 ```
 
+Load uinput module (**kbct will not function but will not produce an error if the uinput module is not loaded**)
+
+```bash
+sudo modprobe uinput
+```
+
 To start KBCT based on YAML configuration file run:
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ There are several ways of installing KBCT
   > Note: The configuration file is expected to be in
   > `/etc/kbct/config.yml`.
 
-  After the installation, run the systemd service:
+  After the installation, run the systemd service (remember to `modprobe uinput` first):
 
   ```
   $ systemctl start kbct


### PR DESCRIPTION
The uinput module is needed by kbct, but kbct will not complain if uinput is not loaded.
This adds mention of the above fact to `readme.md`.

Resolves #25