### PR TITLE
Refactor code.

### DIFF
--- a/src/kbct.rs
+++ b/src/kbct.rs
@@ -254,9 +254,9 @@ impl Kbct {
 		is_complex: bool,
 	) -> Vec<(KeyMapping, KbctKeyStatus)> {
 		use KbctKeyStatus::*;
+		// for all keys activating the layer...
 		active_modifiers
 			.iter()
-			// for all keys activating the layer...
 			.map(|modifier| {
 				self.source_to_mapped
 					.get(modifier)
@@ -266,7 +266,7 @@ impl Kbct {
 						modifier, active_modifiers
 					))
 			})
-			// ... that are pressed ...
+			// ... build an event releasing modifier or restore it as clicked
 			.flat_map(|(modifier, state)| match (state.status, is_complex) {
 				(Clicked, true) => Some((
 					KeyMapping {
@@ -285,7 +285,6 @@ impl Kbct {
 				(Released, _) => panic!("Illegal state"),
 				_ => None,
 			})
-			// ... build an event releasing modifier or restore it as clicked
 			.collect()
 	}
 

--- a/src/kbct.rs
+++ b/src/kbct.rs
@@ -85,12 +85,20 @@ struct KbctKeyState {
 	status: KbctKeyStatus,
 }
 
-#[derive(Debug)]
+/// Structure representing the whole user configuration
+#[derive(Debug, Default)]
 pub struct Kbct {
+    /// Mapping `keycode -> keycode` for the default mapping
 	simple_map: KeyMap,
+    /// Definitions of user layers
+    /// A layer is also a mapping `keycode -> keycode`.
+	/// Each layer is indexed by a set of keycodes enabling it.
 	complex_map: ComplexKeyMap,
+    /// State of each keycode, indexed by the keycode itself
 	source_to_mapped: KeyStateMap,
+    /// ???
 	mapped_to_source: ReverseKeyMap,
+    /// Time of the internal system
 	logic_clock: u64,
 }
 
@@ -113,9 +121,7 @@ impl Kbct {
 		Kbct {
 			simple_map: simple_keymap,
 			complex_map: complex_keymap,
-			source_to_mapped: Default::default(),
-			mapped_to_source: Default::default(),
-			logic_clock: 0,
+			..Default::default()
 		}
 	}
 
@@ -147,7 +153,7 @@ impl Kbct {
 		})
 	}
 
-    // Check that the keys defined in the configuration are all valid
+    /// Check that the keys defined in the configuration are all valid
 	fn check_keys(conf: &KbctConf, key_code: impl Fn(&String) -> Option<i32>) -> Result<()> {
 		let keys = Self::collect_used_keys(conf);
 		let unknown_keys: BTreeSet<&String> = keys.into_iter().filter(|x| key_code(*x).is_none()).collect();
@@ -161,7 +167,7 @@ impl Kbct {
 		}
 	}
 
-    // Collects all keys used through the configuration
+    /// Collects all keys used through the configuration
 	fn collect_used_keys<'a>(conf: &'a KbctConf) -> Vec<&'a String> {
         let mut keys = Vec::new();
 		if let Some(simple) = conf.keymap.as_ref() {

--- a/src/kbct.rs
+++ b/src/kbct.rs
@@ -254,14 +254,17 @@ impl Kbct {
 		is_complex: bool,
 	) -> Vec<(KeyMapping, KbctKeyStatus)> {
 		use KbctKeyStatus::*;
-		println!("mods = {:?}", active_modifiers);
 		active_modifiers
 			.iter()
 			// for all keys activating the layer...
-			.filter_map(|modifier| {
+			.map(|modifier| {
 				self.source_to_mapped
 					.get(modifier)
 					.map(|state| (modifier, state))
+					.expect(&format!(
+						"Modifier {} of keyset {:?} should have been pressed to activate layer",
+						modifier, active_modifiers
+					))
 			})
 			// ... that are pressed ...
 			.flat_map(|(modifier, state)| match (state.status, is_complex) {
@@ -394,10 +397,7 @@ impl Kbct {
 
 		let mut event_orders: Vec<_> = match active_modifiers {
 			Some(keys) => {
-				let is_complex = match (complex_mapped, simple_mapped) {
-					(Some(cm), Some(sm)) => cm == sm,
-					_ => false,
-				};
+				let is_complex = complex_mapped.is_some();
 				self.build_modifier_events(keys, is_complex)
 			}
 			None => vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ extern crate pretty_env_logger;
 extern crate uinput;
 extern crate uinput_sys;
 
-use std::{fs, fs::File, process, thread, time};
 use std::collections::{HashMap, HashSet};
 use std::os::unix::io::{AsRawFd, RawFd};
+use std::{fs, fs::File, process, thread, time};
 
 use clap::Clap;
 use inotify::Inotify;
@@ -41,7 +41,7 @@ impl SignalReceiver {
 			&mask,
 			nix::sys::signalfd::SfdFlags::SFD_NONBLOCK,
 		)
-			.unwrap();
+		.unwrap();
 		let fd = sfd.as_raw_fd();
 		Ok(Box::new(SignalReceiver {
 			signal_fd: (sfd),
@@ -203,7 +203,7 @@ impl EventObserver for DeviceManager {
 				regex.is_match(event.name.unwrap().to_str().unwrap())
 					&& !event.mask.contains(EventMask::ISDIR)
 					&& (event.mask.contains(EventMask::CREATE)
-					|| event.mask.contains(EventMask::DELETE))
+						|| event.mask.contains(EventMask::DELETE))
 			})
 			.is_some();
 
@@ -252,7 +252,7 @@ impl EventObserver for KeyLogger {
 							util::keycodes::code_to_name(kbct_event.code),
 							kbct_event.ev_type
 						)
-							.to_lowercase()
+						.to_lowercase()
 					)
 				}
 			}
@@ -270,8 +270,9 @@ impl EventObserver for KeyLogger {
 fn start_mapper_from_file_conf(config_file: String) -> Result<()> {
 	let config = serde_yaml::from_str(
 		&*std::fs::read_to_string(config_file.as_str())
-			.expect(&format!("Could not open file {}", config_file)))
-		.expect("Could not parse the configuration yaml file");
+			.expect(&format!("Could not open file {}", config_file)),
+	)
+	.expect("Could not parse the configuration yaml file");
 	start_mapper(config)
 }
 
@@ -330,8 +331,8 @@ enum SubCommand {
 struct CliTestReplay {
 	#[clap(short, long)]
 	testcase: String,
-	#[clap(short, long, default_value="DummyDevice")]
-	device_name: String
+	#[clap(short, long, default_value = "DummyDevice")]
+	device_name: String,
 }
 
 #[derive(Clap)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ impl EventObserver for DeviceManager {
 			.is_some();
 
 		if has_updates {
-			DeviceManager::update_captured_kbs(self)
+			self.update_captured_kbs()
 				.map(|observer| ObserverResult::SubscribeNew(observer))
 				.or(Ok(ObserverResult::Nothing))
 		} else {

--- a/src/test.rs
+++ b/src/test.rs
@@ -143,7 +143,7 @@ fn test_map_event() -> Result<()> {
 }
 
 #[test]
-fn test_1() {
+fn test_1_with_consecutive_layers() {
 	let mut kbct = KbctTestContext::new(
 		hashmap! {"1" => "2", "3" => "4"},
 		hashmap! {
@@ -163,7 +163,7 @@ fn test_1() {
 }
 
 #[test]
-fn test_2() {
+fn test_2_with_some_modifier_in_simple_layer() {
 	let mut kbct = KbctTestContext::new(
 		hashmap! {"1" => "2", "3" => "4", "A" => "C"},
 		hashmap! {
@@ -183,7 +183,7 @@ fn test_2() {
 }
 
 #[test]
-fn test_3() {
+fn test_3_with_all_modifiers_in_simple_layer() {
 	let mut kbct = KbctTestContext::new(
 		hashmap! {
 		"X" => "Z",
@@ -204,9 +204,26 @@ fn test_3() {
 	);
 }
 
+#[ignore]
+#[test]
+fn test_with_some_modifier_in_complex_layer() {
+	let mut kbct = KbctTestContext::new(
+		hashmap! {"A" => "B"},
+		hashmap! {
+		btreeset! {"X"} => hashmap!{"Y" => "E", "B" => "A"},
+		btreeset! {"X", "Y"} => hashmap! {"C" => "D"}},
+	);
+
+	kbct.click("X", vec![("X", Clicked)]);
+	kbct.click("Y", vec![("X", ForceReleased), ("E", Clicked)]);
+	kbct.release("C", vec![("E", ForceReleased), ("D", Released)]);
+}
+
 #[test]
 fn test_active_mapping_with_one_possibility() -> Result<()> {
-	let mut ctx = KbctTestContext { kbct: create_test_kbct()?};
+	let mut ctx = KbctTestContext {
+		kbct: create_test_kbct()?,
+	};
 	ctx.just_click("A");
 	let active = ctx.kbct.get_active_complex_modifiers().unwrap();
 	assert_eq!(btreeset![key("A")], *active);
@@ -215,7 +232,9 @@ fn test_active_mapping_with_one_possibility() -> Result<()> {
 
 #[test]
 fn test_active_mapping_with_larger_keyset() -> Result<()> {
-	let mut ctx = KbctTestContext { kbct: create_test_kbct()?};
+	let mut ctx = KbctTestContext {
+		kbct: create_test_kbct()?,
+	};
 	ctx.just_click("A");
 	ctx.just_click("B");
 	let active = ctx.kbct.get_active_complex_modifiers().unwrap();
@@ -225,7 +244,9 @@ fn test_active_mapping_with_larger_keyset() -> Result<()> {
 
 #[test]
 fn test_active_mapping_with_latest_active() -> Result<()> {
-	let mut ctx = KbctTestContext { kbct: create_test_kbct()?};
+	let mut ctx = KbctTestContext {
+		kbct: create_test_kbct()?,
+	};
 	ctx.just_click("A");
 	ctx.just_click("B");
 	ctx.just_click("C");
@@ -236,7 +257,9 @@ fn test_active_mapping_with_latest_active() -> Result<()> {
 
 #[test]
 fn test_active_mapping_without_active() -> Result<()> {
-	let mut ctx = KbctTestContext { kbct: create_test_kbct()?};
+	let mut ctx = KbctTestContext {
+		kbct: create_test_kbct()?,
+	};
 	ctx.just_click("B");
 	let active = ctx.kbct.get_active_complex_modifiers();
 	assert!(active.is_none());

--- a/src/test.rs
+++ b/src/test.rs
@@ -155,9 +155,7 @@ fn test_1() {
 	kbct.click("A", vec![("A", Clicked)]);
 	kbct.click("1", vec![("A", ForceReleased), ("3", Clicked)]);
 	kbct.release("1", vec![("3", Released)]);
-	println!("Before clicking B");
 	kbct.click("B", vec![("A", Clicked), ("B", Clicked)]);
-	println!("After clicking B");
 	kbct.click(
 		"1",
 		vec![("A", ForceReleased), ("B", ForceReleased), ("5", Clicked)],

--- a/src/test.rs
+++ b/src/test.rs
@@ -207,12 +207,12 @@ fn test_active_mapping() -> Result<()> {
 	kbct.map_event(Kbct::make_ev(key("B"), Clicked));
 	kbct.map_event(Kbct::make_ev(key("C"), Clicked));
 	let active = kbct.get_active_complex_modifiers().unwrap();
-	assert_eq!(btreeset![key("A"), key("C")], *active.0);
+	assert_eq!(btreeset![key("A"), key("C")], *active);
 
 	let mut kbct = create_test_kbct()?;
 	kbct.map_event(Kbct::make_ev(key("A"), Clicked));
 	let active = kbct.get_active_complex_modifiers().unwrap();
-	assert_eq!(btreeset![key("A")], *active.0);
+	assert_eq!(btreeset![key("A")], *active);
 
 	let mut kbct = create_test_kbct()?;
 	kbct.map_event(Kbct::make_ev(key("B"), Clicked));

--- a/src/test.rs
+++ b/src/test.rs
@@ -216,20 +216,6 @@ fn test_3_with_all_modifiers_in_simple_layer() {
 	);
 }
 
-#[ignore]
-#[test]
-fn test_with_some_modifier_in_complex_layer() {
-	let mut kbct = KbctTestContext::new(
-		hashmap! {"A" => "B"},
-		hashmap! { btreeset! {"X"} => hashmap!{"Y" => "E", "B" => "A"},
-		btreeset! {"X", "Y"} => hashmap! {"C" => "D"}},
-	);
-
-	kbct.click("X", vec![("X", Clicked)]);
-	kbct.click("Y", vec![("X", ForceReleased), ("E", Clicked)]);
-	kbct.release("C", vec![("E", ForceReleased), ("D", Released)]);
-}
-
 #[test]
 fn test_active_mapping_with_one_possibility() -> Result<()> {
 	let mut ctx = KbctTestContext {

--- a/src/util/util.rs
+++ b/src/util/util.rs
@@ -98,7 +98,7 @@ pub fn map_status_from_linux(val: i32) -> KbctKeyStatus {
 		0 => KbctKeyStatus::Released,
 		1 => KbctKeyStatus::Clicked,
 		2 => KbctKeyStatus::Pressed,
-		_ => panic!(format!("Illegal argument {}", val)),
+		_ => panic!("Illegal argument {}", val),
 	}
 }
 


### PR DESCRIPTION
This PR mainly refactors the code base to extract smaller functions.

The main driver for this refactoring was to be able to understand the logic of the function `map_event`.
To do so, I extracted dedicated functions for each case. And large chains of calls have been moved into functions naming their intent.