### PR TITLE
Support modifiers applied to single key presses

### DIFF
--- a/src/kbct.rs
+++ b/src/kbct.rs
@@ -11,16 +11,52 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+enum KeyPressConf {
+	Mod { modifiers: Vec<String>, key: String },
+	Key(String),
+}
+impl KeyPressConf {
+	fn all_keys(&self) -> Vec<&String> {
+		match self {
+			KeyPressConf::Key(k) => vec![k],
+			KeyPressConf::Mod { modifiers, key } => {
+				modifiers.iter().chain(std::iter::once(key)).collect()
+			}
+		}
+	}
+
+	fn key_press(&self, mut str_to_code: impl FnMut(&String) -> Option<i32>) -> KeyPress {
+		match self {
+			KeyPressConf::Key(key) => KeyPress {
+				code: str_to_code(key).unwrap(),
+				modifiers: Default::default(),
+			},
+			KeyPressConf::Mod { modifiers, key } => KeyPress {
+				code: str_to_code(key).unwrap(),
+				modifiers: modifiers.iter().map(|k| str_to_code(k).unwrap()).collect(),
+			},
+		}
+	}
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 struct KbctComplexConf {
 	modifiers: Vec<String>,
-	keymap: HashMap<String, String>,
+	keymap: HashMap<String, KeyPressConf>,
 }
 
 pub type KbctRootConf = Vec<KbctConf>;
 pub type Result<T> = std::result::Result<T, KbctError>;
 
+#[derive(Debug, Clone)]
+pub struct KeyPress {
+	code: Keycode,
+	modifiers: KeySet,
+}
+
 type Keycode = i32;
-type KeyMap = HashMap<Keycode, Keycode>;
+type KeyMap = HashMap<Keycode, KeyPress>;
 type KeySet = BTreeSet<Keycode>;
 type ComplexKeyMap = HashMap<KeySet, KeyMap>;
 type KeyStateMap = LinkedHashMap<Keycode, KbctKeyState>;
@@ -55,7 +91,7 @@ pub enum KbctError {
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct KbctConf {
 	keyboards: Vec<String>,
-	keymap: Option<HashMap<String, String>>,
+	keymap: Option<HashMap<String, KeyPressConf>>,
 	layers: Option<Vec<KbctComplexConf>>,
 }
 
@@ -85,6 +121,7 @@ pub struct Kbct {
 	complex_map: ComplexKeyMap,
 	source_to_mapped: KeyStateMap,
 	mapped_to_source: ReverseKeyMap,
+	transient_modifiers: KeySet,
 	logic_clock: u64,
 }
 
@@ -109,6 +146,7 @@ impl Kbct {
 			complex_map: complex_keymap,
 			source_to_mapped: Default::default(),
 			mapped_to_source: Default::default(),
+			transient_modifiers: Default::default(),
 			logic_clock: 0,
 		}
 	}
@@ -117,17 +155,19 @@ impl Kbct {
 		let simple = conf.keymap.unwrap_or_default();
 		let complex = conf.layers.unwrap_or_default();
 
-		let unwrap_kv = |(k, v)| vec![k, v];
 		let str_to_code = |k| key_code(k).unwrap();
-		let str_to_code_pair = |(k, v)| (str_to_code(k), str_to_code(v));
+		let str_to_code_pair =
+			|(k, v): (_, &KeyPressConf)| (str_to_code(k), v.key_press(&key_code));
 
 		let all_keys = simple
 			.iter()
-			.flat_map(unwrap_kv)
+			.flat_map(|(k, v)| std::iter::once(k).chain(v.all_keys()))
 			.chain(complex.iter().flat_map(|x| {
-				x.modifiers
-					.iter()
-					.chain(x.keymap.iter().flat_map(unwrap_kv))
+				x.modifiers.iter().chain(
+					x.keymap
+						.iter()
+						.flat_map(|(k, v)| std::iter::once(k).chain(v.all_keys())),
+				)
 			}));
 
 		let unknown_keys: BTreeSet<&String> = all_keys.filter(|x| key_code(*x).is_none()).collect();
@@ -155,6 +195,7 @@ impl Kbct {
 			complex_map,
 			source_to_mapped: LinkedHashMap::new(),
 			mapped_to_source: hashmap!(),
+			transient_modifiers: Default::default(),
 			logic_clock: 0,
 		})
 	}
@@ -232,26 +273,31 @@ impl Kbct {
 		let empty_map = hashmap!();
 		let empty_set = btreeset!();
 
-		let not_mapped = ev.code;
-		let simple_mapped = *self.simple_map.get(&not_mapped).unwrap_or(&not_mapped);
+		let not_mapped = KeyPress {
+			code: ev.code,
+			modifiers: Default::default(),
+		};
+		let simple_mapped = self.simple_map.get(&ev.code).unwrap_or(&not_mapped);
 		let (active_modifiers, complex_keymap) = self
 			.get_active_complex_modifiers()
 			.unwrap_or((&empty_set, &empty_map));
 
-		let complex_mapped = *complex_keymap.get(&not_mapped).unwrap_or(&simple_mapped);
+		let mut is_complex = true;
+		let complex_mapped = complex_keymap.get(&ev.code).unwrap_or_else(|| {
+			is_complex = false;
+			&simple_mapped
+		});
 
-		let prev_state = self.source_to_mapped.get(&not_mapped);
+		let prev_state = self.source_to_mapped.get(&ev.code);
 		let prev_status = prev_state.map(|x| x.status).unwrap_or(Released);
 		let mut result = vec![];
 
 		match (prev_status, ev.ev_type) {
 			(Released, Clicked) => {
-				let synthetic_modifier_events: Vec<_> = active_modifiers
+				let mut synthetic_modifier_events: Vec<_> = active_modifiers
 					.iter()
 					.flat_map(|modifier_raw| {
 						let modifier_mapped = self.source_to_mapped.get(&modifier_raw).unwrap();
-
-						let is_complex = complex_mapped != simple_mapped;
 
 						match (modifier_mapped.status, is_complex) {
 							(Clicked, true) => {
@@ -266,16 +312,43 @@ impl Kbct {
 					})
 					.collect();
 
+				let mapped_code = complex_mapped.code;
+				// Skip transient modifiers that are already being held
+				let transient_modifiers: KeySet = complex_mapped
+					.modifiers
+					.iter()
+					.copied()
+					.filter(|code| {
+						self.mapped_to_source
+							.get(code)
+							.map_or(true, |x| x.is_empty())
+					})
+					.collect();
+
 				for (source, mapped, status) in synthetic_modifier_events.iter() {
 					self.change_key_state(*source, *mapped, *status)
 				}
-				self.change_key_state(not_mapped, complex_mapped, Clicked);
+				self.change_key_state(ev.code, mapped_code, Clicked);
+
+				// Release old transient modifiers and press new ones
+				// The state is not updated, the transient modifiers are released on the next key event
+				synthetic_modifier_events.extend(
+					std::mem::take(&mut self.transient_modifiers)
+						.into_iter()
+						.map(|code| (code, code, Released)),
+				);
+				synthetic_modifier_events.extend(
+					transient_modifiers
+						.iter()
+						.map(|code| (*code, *code, Clicked)),
+				);
+				self.transient_modifiers = transient_modifiers;
 
 				result = synthetic_modifier_events
 					.iter()
 					.map(|(_s, target, st)| Kbct::make_ev(*target, *st))
 					.collect();
-				result.push(Kbct::make_ev(complex_mapped, Clicked));
+				result.push(Kbct::make_ev(mapped_code, Clicked));
 			}
 			(Clicked, Released) | (Pressed, Released) => {
 				if prev_state.is_none() {
@@ -290,12 +363,18 @@ impl Kbct {
 					if down_keys == 1 {
 						result.push(Kbct::make_ev(prev_mapped_code, Released));
 					}
-					self.change_key_state(not_mapped, prev_mapped_code, Released);
+					// Release any pending transient modifiers
+					result.extend(
+						std::mem::take(&mut self.transient_modifiers)
+							.into_iter()
+							.map(|code| Kbct::make_ev(code, Released)),
+					);
+					self.change_key_state(ev.code, prev_mapped_code, Released);
 				}
 			}
 			(ForceReleased, Released) => {
 				let prev_code = prev_state.unwrap().mapped_code;
-				self.change_key_state(not_mapped, prev_code, Released);
+				self.change_key_state(ev.code, prev_code, Released);
 			}
 			(Clicked, Pressed) | (Pressed, Pressed) => {
 				let mapped = prev_state.unwrap().mapped_code;


### PR DESCRIPTION
Fixes https://github.com/samvel1024/kbct/issues/13, at least for the use case described there:

```yaml
- keyboards: [ "AT Translated Set 2 keyboard"]

  layers:
    - modifiers: ['rightshift']
      keymap:
        apostrophe:
          modifiers: ['rightalt']
          key: q
```

The modifiers listed in a keybinding are pressed until the next event, then released, so if you pressed `'`, then tapped `a` while still holding `'`, and finally released `'`, with the above configuration, it would produce:
```
+rightalt +q
-rightalt +a
-a
-q
```